### PR TITLE
Adding eltype, removing constructors, and fixing parameterization

### DIFF
--- a/src/CompleteGraph.jl
+++ b/src/CompleteGraph.jl
@@ -1,10 +1,9 @@
 
 struct CompleteGraph{T<:Integer} <: LG.AbstractGraph{T}
-    nv::Int
+    nv::T
 end
 
-CompleteGraph(nv::Integer) = CompleteGraph{Int}(nv)
-
+LG.eltype(::CompleteGraph{T}) where T = T
 LG.edgetype(::CompleteGraph) = LG.Edge{Int}
 LG.is_directed(::Type{<:CompleteGraph}) = false
 LG.nv(g::CompleteGraph) = g.nv

--- a/src/CompleteGraph.jl
+++ b/src/CompleteGraph.jl
@@ -3,8 +3,8 @@ struct CompleteGraph{T<:Integer} <: LG.AbstractGraph{T}
     nv::T
 end
 
-LG.eltype(::CompleteGraph{T}) where T = T
-LG.edgetype(::CompleteGraph) = LG.Edge{Int}
+LG.eltype(::CompleteGraph{T}) where {T} = T
+LG.edgetype(::CompleteGraph{T}) where {T} = LG.Edge{T}
 LG.is_directed(::Type{<:CompleteGraph}) = false
 LG.nv(g::CompleteGraph) = g.nv
 LG.ne(g::CompleteGraph) = div(nv(g) * (nv(g)-1), 2)

--- a/src/PathGraph.jl
+++ b/src/PathGraph.jl
@@ -7,15 +7,15 @@ A path graph, with each node linked to the previous and next one.
 struct PathGraph{T<:Integer} <: LG.AbstractGraph{T}
     nv::T
     function PathGraph{T}(nv::T) where {T<:Integer}
-        _nv = nv >= 0 ? T(nv) : 0
+        _nv = nv >= 0 ? T(nv) : zero(T)
         new{T}(_nv)
     end
 end
 
 PathGraph(nv::T) where {T<:Integer} = PathGraph{T}(nv)
 
-LG.eltype(::PathGraph{T}) where T = T
-LG.edgetype(::PathGraph) = LG.Edge{Int}
+LG.eltype(::PathGraph{T}) where {T} = T
+LG.edgetype(::PathGraph{T}) where {T} = LG.Edge{T}
 LG.is_directed(::Type{<:PathGraph}) = false
 LG.nv(g::PathGraph) = g.nv
 LG.ne(g::PathGraph) = LG.nv(g) - 1

--- a/src/PathGraph.jl
+++ b/src/PathGraph.jl
@@ -5,15 +5,16 @@
 A path graph, with each node linked to the previous and next one.
 """
 struct PathGraph{T<:Integer} <: LG.AbstractGraph{T}
-    nv::Int
-    function PathGraph{T}(nv::Integer) where {T<:Integer}
-        _nv = nv >= 0 ? Int(nv) : 0
+    nv::T
+    function PathGraph{T}(nv::T) where {T<:Integer}
+        _nv = nv >= 0 ? T(nv) : 0
         new{T}(_nv)
     end
 end
 
-PathGraph(nv::Integer) = PathGraph{Int}(nv)
+PathGraph(nv::T) where {T<:Integer} = PathGraph{T}(nv)
 
+LG.eltype(::PathGraph{T}) where T = T
 LG.edgetype(::PathGraph) = LG.Edge{Int}
 LG.is_directed(::Type{<:PathGraph}) = false
 LG.nv(g::PathGraph) = g.nv

--- a/src/WheelGraph.jl
+++ b/src/WheelGraph.jl
@@ -1,10 +1,9 @@
 
 struct WheelGraph{T <: Integer} <: LG.AbstractGraph{T}
-    nv::Int
+    nv::T
 end
 
-WheelGraph(nv::T) where {T<:Integer} = WheelGraph{T}(Int(nv))
-
+LG.eltype(::WheelGraph{T}) where T = T
 LG.edgetype(::WheelGraph) = LG.Edge{Int}
 LG.is_directed(::Type{<:WheelGraph}) = false
 LG.nv(g::WheelGraph) = g.nv

--- a/src/WheelGraph.jl
+++ b/src/WheelGraph.jl
@@ -3,8 +3,8 @@ struct WheelGraph{T <: Integer} <: LG.AbstractGraph{T}
     nv::T
 end
 
-LG.eltype(::WheelGraph{T}) where T = T
-LG.edgetype(::WheelGraph) = LG.Edge{Int}
+LG.eltype(::WheelGraph{T}) where {T} = T
+LG.edgetype(::WheelGraph{T}) where {T} = LG.Edge{T}
 LG.is_directed(::Type{<:WheelGraph}) = false
 LG.nv(g::WheelGraph) = g.nv
 LG.ne(g::WheelGraph) = (LG.nv(g)-1) * 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,8 @@ using LightGraphs: Edge, edges
     @test !LG.is_directed(WheelGraph{UInt})
     wg = WheelGraph(10)
     wgref = LG.WheelGraph(10)
+    @test eltype(wg) == Int
+    @test eltype(WheelGraph{Int8}(Int8(5))) == Int8
     @test LG.edgetype(wg) <: Edge
     @test LG.has_vertex(wg, 10)
     @test !LG.has_vertex(wg, 11)
@@ -34,6 +36,8 @@ end
 
 @testset "PathGraph" begin
     pg = PathGraph(10)
+    @test eltype(pg) == Int
+    @test eltype(PathGraph{Int8}(Int8(5))) == Int8
     @test !LG.is_directed(PathGraph)
     @test !LG.is_directed(PathGraph{Int})
     @test !LG.is_directed(PathGraph{UInt})
@@ -59,6 +63,8 @@ end
 
 @testset "CompleteGraph" begin
     cg = CompleteGraph(10)
+    @test eltype(cg) == Int
+    @test eltype(CompleteGraph{Int8}(Int8(5))) == Int8
     @test !LG.is_directed(CompleteGraph)
     @test !LG.is_directed(CompleteGraph{Int})
     @test !LG.is_directed(CompleteGraph{UInt})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ using LightGraphs: Edge, edges
     wgref = LG.WheelGraph(10)
     @test eltype(wg) == Int
     @test eltype(WheelGraph{Int8}(Int8(5))) == Int8
+    @test LG.edgetype(WheelGraph{Int8}(Int8(5))) == LG.Edge{Int8}
     @test LG.edgetype(wg) <: Edge
     @test LG.has_vertex(wg, 10)
     @test !LG.has_vertex(wg, 11)
@@ -38,6 +39,7 @@ end
     pg = PathGraph(10)
     @test eltype(pg) == Int
     @test eltype(PathGraph{Int8}(Int8(5))) == Int8
+    @test LG.edgetype(PathGraph{Int8}(Int8(5))) == LG.Edge{Int8}
     @test !LG.is_directed(PathGraph)
     @test !LG.is_directed(PathGraph{Int})
     @test !LG.is_directed(PathGraph{UInt})
@@ -65,6 +67,7 @@ end
     cg = CompleteGraph(10)
     @test eltype(cg) == Int
     @test eltype(CompleteGraph{Int8}(Int8(5))) == Int8
+    @test LG.edgetype(CompleteGraph{Int8}(Int8(5))) == LG.Edge{Int8}
     @test !LG.is_directed(CompleteGraph)
     @test !LG.is_directed(CompleteGraph{Int})
     @test !LG.is_directed(CompleteGraph{UInt})


### PR DESCRIPTION
This fixes the parameterization of the special graph types so that `nv` is the same as the given parameter.

This PR also removes unnecessary outer constructors and adds `Base.eltype` for all the graphs.