### PR TITLE
Add cycle graph

### DIFF
--- a/src/CycleGraph.jl
+++ b/src/CycleGraph.jl
@@ -1,0 +1,132 @@
+
+struct CycleGraph{T<:Integer} <: LG.AbstractGraph{T}
+    nv::T
+
+    function CycleGraph{T}(nv) where {T}
+       
+        nv = convert(T, nv)
+        nv >= zero(T) || throw(ArgumentError("nv must be >= 0"))
+
+        return new{T}(nv)
+    end
+end
+
+CycleGraph(nv) = CycleGraph{typeof(nv)}(nv)
+
+
+Base.eltype(::Type{CycleGraph{T}}) where {T} = T
+Base.eltype(g::CycleGraph) = eltype(typeof(g))
+LG.edgetype(::Type{CycleGraph{T}}) where {T} = LG.Edge{T}
+LG.edgetype(g::CycleGraph{T}) where {T} = edgetype(typeof(g))
+
+LG.is_directed(::Type{<:CycleGraph}) = false
+
+LG.nv(g::CycleGraph) = g.nv
+
+function LG.ne(g::CycleGraph)
+    nvg = Int(LG.nv(g))
+    
+    nvg >= 3 && return nvg
+    nvg == 2 && return 1
+    return 0
+end
+
+
+LG.vertices(g::CycleGraph{T}) where {T} = Base.OneTo(LG.nv(g))
+LG.has_vertex(g::CycleGraph, v) = v in LG.vertices(g)
+
+function LG.has_edge(g::CycleGraph{T}, u, v) where {T}
+
+    u, v = minmax(u, v)
+    nvg = LG.nv(g)
+    oneT = one(T)
+    isinbounds = (oneT <= u) & (v <= nvg) 
+    isedge = (v - u == oneT) | ((u == oneT) & (v == nvg))  
+    return isinbounds & isedge
+end
+
+LG.edges(g::CycleGraph) = LG.SimpleGraphs.SimpleEdgeIter(g)
+
+Base.eltype(::Type{<:LG.SimpleGraphs.SimpleEdgeIter{G}}) where {T, G <: CycleGraph{T}} = LG.Edge{T}
+
+function LG.iterate(iter::LG.SimpleGraphs.SimpleEdgeIter{G}) where {G <: CycleGraph}
+
+    g = iter.g
+    nvg = LG.nv(g)
+    T = eltype(g)
+
+    nvg <= one(T) && return nothing
+
+    e = LG.Edge{T}(one(T), T(2))
+    nvg == T(2) && return e, T(2)
+
+    return e, T(1) 
+end
+
+function LG.iterate(iter::LG.SimpleGraphs.SimpleEdgeIter{G}, state) where {G <: CycleGraph}
+
+    g = iter.g
+    nvg = nv(g)
+    T = eltype(g) 
+
+   state == nvg && return nothing
+    src = state
+    dst = ifelse(state == one(T), nvg, state + one(T))
+    e = LG.Edge{T}(src, dst)
+        
+    return e, (state + one(T))
+
+end
+
+
+struct OutNeighborsIter{G <: LG.AbstractGraph, T}
+    graph::G
+    vertex::T
+end
+
+# TODO inbounds check
+LG.outneighbors(g::CycleGraph, v::Integer) = OutNeighborsIter(g, eltype(g)(v))
+
+LG.inneighbors(g::CycleGraph, v::Integer) = LG.outneighbors(g, v)
+LG.neighbors(g::CycleGraph, v::Integer) = LG.outneighbors(g, v)
+LG.all_neighbors(g::CycleGraph, v::Integer) = LG.outneighbors(g, v)
+
+Base.eltype(::Type{<:OutNeighborsIter{G}}) where {G <: CycleGraph} = eltype(G)  
+
+function LG.iterate(iter::OutNeighborsIter{G, T}) where {T, G <: CycleGraph{T}}
+
+    g = iter.graph
+    v = iter.vertex
+    nvg = nv(g)
+
+    nvg <= one(T) && return nothing
+    nvg == T(2)   && return (T(3) - v), zero(T)
+    v == one(T)   && return v + one(T),       nvg
+    v == nvg      && return one(T),     (v - one(T))
+
+    return (v - one(T)), (v + one(T))
+end
+
+function LG.iterate(iter::OutNeighborsIter{G, T}, state) where {T, G <: CycleGraph{T}}
+
+    g = iter.graph
+
+    state == zero(T) && return nothing
+    return state, zero(T)
+end
+
+function Base.length(iter::OutNeighborsIter{G, T}) where {T, G <: CycleGraph{T}}
+
+    g = iter.graph
+    nvg = nv(g)
+
+    nvg <= one(T) && return 0
+    nvg <= T(2) && return 1
+
+    return 2
+end
+
+LG.SimpleGraph(g::CycleGraph) = LG.cycle_graph(nv(g))
+
+
+

--- a/src/CycleGraph.jl
+++ b/src/CycleGraph.jl
@@ -25,7 +25,7 @@ struct CycleGraph{T<:Integer} <: LG.AbstractGraph{T}
     end
 end
 
-CycleGraph(nv) = CycleGraph{typeof(nv)}(nv)
+CycleGraph(nv::T) where {T<: Integer} = CycleGraph{T}(nv)
 
 
 # =======================================================

--- a/src/CycleGraph.jl
+++ b/src/CycleGraph.jl
@@ -17,7 +17,7 @@ CycleGraph(nv) = CycleGraph{typeof(nv)}(nv)
 Base.eltype(::Type{CycleGraph{T}}) where {T} = T
 Base.eltype(g::CycleGraph) = eltype(typeof(g))
 LG.edgetype(::Type{CycleGraph{T}}) where {T} = LG.Edge{T}
-LG.edgetype(g::CycleGraph{T}) where {T} = edgetype(typeof(g))
+LG.edgetype(g::CycleGraph{T}) where {T} = LG.edgetype(typeof(g))
 
 LG.is_directed(::Type{<:CycleGraph}) = false
 

--- a/src/CycleGraph.jl
+++ b/src/CycleGraph.jl
@@ -3,6 +3,16 @@
 #         CycleGraph struct
 # =======================================================
 
+"""
+    CycleGraph <: AbstractGraph
+
+A structure representing an undirected cycle graph.
+
+A `CycleGraph` with one vertex is a single vertex without any edges (no self-loops)
+and a `CycleGraph` with two vertices is a single edge.
+
+See also: [`LightGraphs.cycle_graph`](@ref)
+"""
 struct CycleGraph{T<:Integer} <: LG.AbstractGraph{T}
     nv::T
 

--- a/src/CycleGraph.jl
+++ b/src/CycleGraph.jl
@@ -121,8 +121,6 @@ end
 LG.outneighbors(g::CycleGraph, v::Integer) = OutNeighborsIter(g, eltype(g)(v))
 
 LG.inneighbors(g::CycleGraph, v::Integer) = LG.outneighbors(g, v)
-LG.neighbors(g::CycleGraph, v::Integer) = LG.outneighbors(g, v)
-LG.all_neighbors(g::CycleGraph, v::Integer) = LG.outneighbors(g, v)
 
 # ---- neighbors iterator -----------------------------------
 

--- a/src/CycleGraph.jl
+++ b/src/CycleGraph.jl
@@ -116,16 +116,11 @@ LG.all_neighbors(g::CycleGraph, v::Integer) = LG.outneighbors(g, v)
 
 # ---- neighbors iterator -----------------------------------
 
-struct OutNeighborsIter{T, G <: LG.AbstractGraph{T}}
-    graph::G
-    vertex::T
-end
 
-Base.eltype(::Type{<:OutNeighborsIter{T, G}}) where {T, G} = eltype(G)  
-
-function LG.iterate(iter::OutNeighborsIter{T, G}) where {T, G <: CycleGraph}
+function LG.iterate(iter::OutNeighborsIter{V, <:CycleGraph}) where {V}
 
     g = iter.graph
+    T = eltype(g)
     v = iter.vertex
     nvg = nv(g)
 
@@ -137,17 +132,19 @@ function LG.iterate(iter::OutNeighborsIter{T, G}) where {T, G <: CycleGraph}
     return (v - one(T)), (v + one(T))
 end
 
-function LG.iterate(iter::OutNeighborsIter{T, G}, state) where {T, G <: CycleGraph}
+function LG.iterate(iter::OutNeighborsIter{V, <:CycleGraph}, state) where {V}
 
     g = iter.graph
+    T = eltype(g)
 
     state == zero(T) && return nothing
     return state, zero(T)
 end
 
-function Base.length(iter::OutNeighborsIter{T, G}) where {T, G <: CycleGraph}
+function Base.length(iter::OutNeighborsIter{V, <:CycleGraph}) where {V}
 
     g = iter.graph
+    T = eltype(g)
     nvg = nv(g)
 
     nvg <= one(T) && return 0

--- a/src/SpecialGraphs.jl
+++ b/src/SpecialGraphs.jl
@@ -3,12 +3,15 @@ module SpecialGraphs
 import LightGraphs
 const LG = LightGraphs
 
+import Base.eltype
+
 using LightGraphs: nv, ne, outneighbors,
                    inneighbors, vertices, edges, Edge,
                    has_vertex, has_edge
 
-export WheelGraph, PathGraph, CompleteGraph
+export CycleGraph, WheelGraph, PathGraph, CompleteGraph
 
+include("CycleGraph.jl")
 include("WheelGraph.jl")
 include("PathGraph.jl")
 include("CompleteGraph.jl")

--- a/src/SpecialGraphs.jl
+++ b/src/SpecialGraphs.jl
@@ -11,6 +11,7 @@ using LightGraphs: nv, ne, outneighbors,
 
 export CycleGraph, WheelGraph, PathGraph, CompleteGraph
 
+include("utils.jl")
 include("CycleGraph.jl")
 include("WheelGraph.jl")
 include("PathGraph.jl")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,14 @@
+
+
+"""
+    OutNeighborsIter
+
+A structure for iterating over the out neighbors in a graph for a certain vertex.
+"""
+struct OutNeighborsIter{V, G <: LG.AbstractGraph{V}}
+    graph::G
+    vertex::V
+end
+
+Base.eltype(::Type{<:OutNeighborsIter{V, G}}) where {V, G} = eltype(G)  
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -197,6 +197,10 @@ end
         @testset "outneigbors(g, $v)" for v in (unique([1, 2, n - 1, n]) ∩ LG.vertices(g))
             outneighbors = LG.outneighbors(g, v)
 
+            @testset "same as inneighbors" begin
+                @test LG.inneighbors(g, v) == outneighbors
+            end
+
             @testset "eltype" begin
                 @test eltype(outneighbors) == T
                 @test eltype(typeof(outneighbors)) == T
@@ -236,6 +240,13 @@ end
                     @test (n1, n2) == (n1_expected, n2_expected)
                 end
             end
+        end
+
+        @testset "converting to SimpleGraph" begin
+
+            gsimple = LG.SimpleGraph(g)
+            @test gsimple == LG.cycle_graph(T(n))
+            @test eltype(g) == eltype(gsimple)
         end
 
         @testset "pagerank" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,3 +90,149 @@ end
         end
     end
 end
+
+@testset "CycleGraph" begin
+    @testset "CycleGraph{T}(n): (T = $T, n = $n)" for
+        T in [UInt8, Int32, Int64],
+        n in [0, 1, 2, 3, 8] ∪ (T == UInt8 ? (255,) : ()) # extremal case for UInt8
+
+        @testset "Constructor CycleGraph(n::T)" begin
+            g = CycleGraph(T(n))
+
+            @test typeof(g) == CycleGraph{T}
+            @test LG.nv(g) == n
+        end
+
+        @testset "Constructor CycleGraph{T}(n)" begin
+            g = CycleGraph{T}(n)
+
+            @test typeof(g) == CycleGraph{T}
+            @test LG.nv(g) == n
+        end
+
+        g = CycleGraph{T}(n)
+
+        @testset "vertices(g)" begin
+            @test eltype(LG.vertices(g)) == T
+            @test collect(LG.vertices(g)) == 1:n
+        end
+
+        @testset "ne(g)" begin
+            @test typeof(LG.ne(g)) == Int
+            ne_expected =
+                if n == 0 || n == 1
+                    0
+                elseif n == 2
+                    1
+                else
+                    n
+                end
+            @test LG.ne(g) == ne_expected
+        end
+
+        @testset "eltype" begin
+            @test eltype(g) == T
+            @test eltype(typeof(g)) == T
+        end
+
+        @testset "edgetype" begin
+            @test LG.edgetype(g) == LG.Edge{T}
+            @test LG.edgetype(typeof(g)) == LG.Edge{T}
+        end
+
+        @testset "is_directed" begin
+            @test LG.is_directed(typeof(g)) == false
+        end
+
+        @testset "has_vertex(g, $v)" for
+            v in [-1, 0, 1, 2, 255]
+
+            has_vertex_expected = v ∈ 1:n
+            @test LG.has_vertex(g, v) == has_vertex_expected
+        end
+
+        @testset "has_edge(g, $src, $dst)" for
+            (src, dst) in [(1, 2), (2, 1), (1, 3), (0, 1), (1, n), (n, 1), (n, n +1)]
+
+            has_edge_expected =
+                src in 1:n && dst in 1:n &&
+                ((max(src, dst) - min(src, dst) == 1) || (min(src, dst) == 1 && max(src, dst) == n))
+
+            @test LG.has_edge(g, src, dst) == has_edge_expected
+        end
+
+        @testset "edges(g)" begin
+            edges = LG.edges(g)
+
+            @testset "eltype" begin
+                @test eltype(edges) == LG.edgetype(g)
+                @test eltype(typeof(edges)) == LG.edgetype(g)
+            end
+
+            @testset "length" begin
+                @test length(edges) == LG.ne(g)
+            end
+
+            @testset "lexicographicaly sorted and unique" begin
+                # No order defined on Edge so we convert to Tuple first
+                tuples = map(Tuple, edges)
+                @test issorted(tuples)
+                @test allunique(tuples)
+            end
+
+            @testset "are edges of g" begin
+                @test all(e -> LG.has_edge(g, e), edges)
+            end
+        end
+
+        @testset "outneigbors(g, $v)" for v in (unique([1, 2, n - 1, n]) ∩ LG.vertices(g))
+            outneighbors = LG.outneighbors(g, v)
+
+            @testset "eltype" begin
+                @test eltype(outneighbors) == T
+                @test eltype(typeof(outneighbors)) == T
+            end
+
+            @testset "length" begin
+                length_expected =
+                    if n == 0 || n == 1
+                        0
+                    elseif n == 2
+                        1
+                    else
+                        2
+                    end
+                @test length(outneighbors) == length_expected
+            end
+
+            @testset "issorted and unique" begin
+                @test issorted(outneighbors)
+                @test allunique(outneighbors)
+            end
+
+            @testset "correct values" begin
+                if n == 2
+                    @test first(outneighbors) == (v == 1 ? 2 : 1)
+                elseif n >= 3
+                    n1, n2 = outneighbors
+
+                    n1_expected, n2_expected =
+                        if v == 1
+                            (2, n)
+                        elseif v == n
+                            (1, n - 1)
+                        else
+                            (v - 1, v + 1)
+                        end
+                    @test (n1, n2) == (n1_expected, n2_expected)
+                end
+            end
+        end
+
+        @testset "pagerank" begin
+            if n > 0 # pagerank does not work for empty graphs
+                @test LG.pagerank(g) ≈ LG.pagerank(LG.cycle_graph(T(n)))
+            end
+        end
+    end
+end


### PR DESCRIPTION
This PR adds a `CycleGraph` structure. Not sure if we actually need something as simple but it was a good exercise for met to figure out how to such code should be written for more complicated graphs later.

Some observations:

- Is is tedious to write the `LG` prefix all the time, maybe we should import the functions that we want to overwrite instead.

- For the neighbors of a vertex I have created a separate iterator structure. This has the advantage  that we do not have to allocate vectors although I cannot say if this does improve performance. This created some problems with the `@simd`  macro in LightGraphs, as this macro expects something indexable instead of a simple iterator. Most of these macros in LightGraphs where wrong anyway, so I created a pr (https://github.com/JuliaGraphs/LightGraphs.jl/pull/1252) to remove them. But I was thinking, maybe this iterator structure should also supports indexing or we make it a subtype of `AbstractArray`.

- I also created a conversion to `SimpleGraph` by overloading the `SimpleGraph` constructor, but maybe we should relay on the `convert` function instead, as the `SimpleGraph` constructor already has a lot of methods and this makes it difficult for users to figure out how to use it.

- Maybe we should add a `AbstractSpecialGraph <: AbstractGraph` type, so that we can have some common methods. Maybe we could also have a  `AbstractSpecialSimpleGraph <: AbstractSimpleGraph`  (or `SpecialSimpleGraph` might be shorter) type.

- This package might be a good place to do some experiments with traits, as the SpecialGraphs are immutable.