### PR TITLE
Vectors for neighbors/edges for CycleGraphs

### DIFF
--- a/src/CycleGraph.jl
+++ b/src/CycleGraph.jl
@@ -87,10 +87,9 @@ function Base.size(edgevec::SimpleEdgeVector{V, G}) where {V, G <: CycleGraph}
     return (ne(g), )
 end
 
-# TODO propagate inbounds
-function Base.getindex(edgevec::SimpleEdgeVector{V, G}, i::Int) where {V, G <: CycleGraph}
+@inline function Base.getindex(edgevec::SimpleEdgeVector{V, G}, i::Int) where {V, G <: CycleGraph}
 
-    i ∈ Base.OneTo(length(edgevec)) || throw(BoundsError(edgevec, i))
+    @boundscheck i ∈ Base.OneTo(length(edgevec)) || throw(BoundsError(edgevec, i))
 
     g = edgevec.graph
     T = eltype(g)
@@ -108,8 +107,12 @@ Base.IndexStyle(::Type{<:SimpleEdgeVector{V, G}}) where {V, G <: CycleGraph} = I
 #        neighbors
 # =======================================================
 
-# TODO maybe we want an inbounds check
-LG.outneighbors(g::CycleGraph, v::Integer) = OutNeighborVector(g, eltype(g)(v))
+@inline function LG.outneighbors(g::CycleGraph, v::Integer)
+
+    @boundscheck v ∈ vertices(g) || throw(BoundError(g, v))
+
+    return OutNeighborVector(g, eltype(g)(v))
+end
 
 LG.inneighbors(g::CycleGraph, v::Integer) = LG.outneighbors(g, v)
 
@@ -126,10 +129,9 @@ function Base.size(nbs::OutNeighborVector{V, G}) where {V, G <: CycleGraph}
     return (2,)
 end
 
-# TODO propagate inbounds
-function Base.getindex(nbs::OutNeighborVector{V, G}, i::Int) where {V, G <: CycleGraph}
+@inline function Base.getindex(nbs::OutNeighborVector{V, G}, i::Int) where {V, G <: CycleGraph}
 
-    i ∈ Base.OneTo(length(nbs)) || throw(BoundsError(nbs, i))
+    @boundscheck i ∈ Base.OneTo(length(nbs)) || throw(BoundsError(nbs, i))
 
     g = nbs.graph
     T = eltype(g)

--- a/src/CycleGraph.jl
+++ b/src/CycleGraph.jl
@@ -1,0 +1,132 @@
+
+struct CycleGraph{T<:Integer} <: LG.AbstractGraph{T}
+    nv::T
+
+    function CycleGraph{T}(nv) where {T}
+       
+        nv = convert(T, nv)
+        nv >= zero(T) || throw(ArgumentError("nv must be >= 0"))
+
+        return new{T}(nv)
+    end
+end
+
+CycleGraph(nv) = CycleGraph{typeof(nv)}(nv)
+
+
+Base.eltype(::Type{CycleGraph{T}}) where {T} = T
+Base.eltype(g::CycleGraph) = eltype(typeof(g))
+LG.edgetype(::Type{CycleGraph{T}}) where {T} = LG.Edge{T}
+LG.edgetype(g::CycleGraph{T}) where {T} = edgetype(typeof(g))
+
+LG.is_directed(::Type{<:CycleGraph}) = false
+
+LG.nv(g::CycleGraph) = g.nv
+
+function LG.ne(g::CycleGraph)
+    nvg = Int(LG.nv(g))
+    
+    nvg >= 3 && return nvg
+    nvg == 2 && return 1
+    return 0
+end
+
+
+LG.vertices(g::CycleGraph{T}) where {T} = Base.OneTo(LG.nv(g))
+LG.has_vertex(g::CycleGraph, v) = v in LG.vertices(g)
+
+function LG.has_edge(g::CycleGraph{T}, u, v) where {T}
+
+    u, v = minmax(u, v)
+    nvg = LG.nv(g)
+    oneT = one(T)
+    isinbounds = (oneT <= u) & (v <= nvg) 
+    isedge = (v - u == oneT) | ((u == oneT) & (v == nvg))  
+    return isinbounds & isedge
+end
+
+LG.edges(g::CycleGraph) = LG.SimpleGraphs.SimpleEdgeIter(g)
+
+Base.eltype(::Type{<:LG.SimpleGraphs.SimpleEdgeIter{G}}) where {T, G <: CycleGraph{T}} = LG.Edge{T}
+
+function LG.iterate(iter::LG.SimpleGraphs.SimpleEdgeIter{G}) where {G <: CycleGraph}
+
+    g = iter.g
+    nvg = LG.nv(g)
+    T = eltype(g)
+
+    nvg <= one(T) && return nothing
+
+    e = LG.Edge{T}(one(T), T(2))
+    nvg == T(2) && return e, T(2)
+
+    return e, T(1) 
+end
+
+function LG.iterate(iter::LG.SimpleGraphs.SimpleEdgeIter{G}, state) where {G <: CycleGraph}
+
+    g = iter.g
+    nvg = nv(g)
+    T = eltype(g) 
+
+   state == nvg && return nothing
+    src = state
+    dst = ifelse(state == one(T), nvg, state + one(T))
+    e = LG.Edge{T}(src, dst)
+        
+    return e, (state + one(T))
+
+end
+
+
+struct OutNeighborsIter{G <: LG.AbstractGraph, T}
+    graph::G
+    vertex::T
+end
+
+# TODO inbounds check
+LG.outneighbors(g::CycleGraph, v::Integer) = OutNeighborsIter(g, eltype(g)(v))
+
+LG.inneighbors(g::CycleGraph, v::Integer) = LG.outneighbors(g, v)
+LG.neighbors(g::CycleGraph, v::Integer) = LG.outneighbors(g, v)
+LG.all_neighbors(g::CycleGraph, v::Integer) = LG.outneighbors(g, v)
+
+Base.eltype(::Type{<:OutNeighborsIter{G}}) where {G <: CycleGraph} = eltype(G)  
+
+function LG.iterate(iter::OutNeighborsIter{G, T}) where {T, G <: CycleGraph{T}}
+
+    g = iter.graph
+    v = iter.vertex
+    nvg = nv(g)
+
+    nvg <= one(T) && return nothing
+    nvg == T(2)   && return (T(3) - v), zero(T)
+    v == one(T)   && return v + one(T),       nvg
+    v == nvg      && return one(T),     (v - one(T))
+
+    return (v - one(T)), (v + one(T))
+end
+
+function LG.iterate(iter::OutNeighborsIter{G, T}, state) where {T, G <: CycleGraph{T}}
+
+    g = iter.graph
+
+    state == zero(T) && return nothing
+    return state, zero(T)
+end
+
+function Base.length(iter::OutNeighborsIter{G, T}) where {T, G <: CycleGraph{T}}
+
+    g = iter.graph
+    nvg = nv(g)
+
+    nvg <= one(T) && return 0
+    nvg <= T(2) && return 1
+
+    return 2
+end
+
+LG.SimpleGraph(g::CycleGraph) = LG.cycle_graph(nv(g))
+
+
+

--- a/src/CycleGraph.jl
+++ b/src/CycleGraph.jl
@@ -136,12 +136,15 @@ function Base.getindex(nbs::OutNeighborVector{V, G}, i::Int) where {V, G <: Cycl
     v::T = nbs.vertex
     nvg::T = nv(g)
 
-    nvg == T(2) && return T(2) - v
     if i == 1
-        return (v == one(T)) ? T(2) : (v - one(T))
+        v == one(T) && return T(2)
+        v == nvg && return one(T)
+        return v - one(T)
     end
     # i == 2
-    return (v == nvg) ? (nvg(T) - 1) : (v + one(T))
+    v == one(T) && return nvg
+    v == nvg && return nvg - T(1)
+    return v + one(T)
 end
 
 Base.IndexStyle(::Type{<:OutNeighborVector{V, G}}) where {V, G <: CycleGraph} = IndexLinear()

--- a/src/CycleGraph.jl
+++ b/src/CycleGraph.jl
@@ -13,7 +13,7 @@ and a `CycleGraph` with two vertices is a single edge.
 
 See also: [`LightGraphs.cycle_graph`](@ref)
 """
-struct CycleGraph{T<:Integer} <: LG.AbstractGraph{T}
+struct CycleGraph{T<:Integer} <: AbstractGraph{T}
     nv::T
 
     function CycleGraph{T}(nv) where {T}
@@ -42,23 +42,23 @@ LG.is_directed(::Type{<:CycleGraph}) = false
 Base.eltype(::Type{CycleGraph{T}}) where {T} = T
 Base.eltype(g::CycleGraph) = eltype(typeof(g))
 
-LG.edgetype(::Type{CycleGraph{T}}) where {T} = LG.Edge{T}
+LG.edgetype(::Type{CycleGraph{T}}) where {T} = Edge{T}
 
 LG.nv(g::CycleGraph) = g.nv
 
-LG.vertices(g::CycleGraph{T}) where {T} = Base.OneTo(LG.nv(g))
+LG.vertices(g::CycleGraph{T}) where {T} = Base.OneTo(nv(g))
 
-LG.has_vertex(g::CycleGraph, v) = v in LG.vertices(g)
+LG.has_vertex(g::CycleGraph, v) = v in vertices(g)
 
 
 # =======================================================
 #        edges
 # =======================================================
 
-LG.edgetype(g::CycleGraph{T}) where {T} = LG.edgetype(typeof(g))
+LG.edgetype(g::CycleGraph{T}) where {T} = edgetype(typeof(g))
 
 function LG.ne(g::CycleGraph)
-    nvg = Int(LG.nv(g))
+    nvg = Int(nv(g))
     
     nvg >= 3 && return nvg
     nvg == 2 && return 1
@@ -69,7 +69,7 @@ end
 function LG.has_edge(g::CycleGraph{T}, u, v) where {T}
 
     u, v = minmax(u, v)
-    nvg = LG.nv(g)
+    nvg = nv(g)
     oneT = one(T)
     isinbounds = (oneT <= u) & (v <= nvg) 
     isedge = (v - u == oneT) | ((u == oneT) & (v == nvg))  
@@ -95,9 +95,9 @@ end
     T = eltype(g)
     nvg::T = nv(g)
 
-    i == 1 && return LG.Edge(one(T), T(2))
-    i == 2 && return LG.Edge(one(T), nvg)
-    return LG.Edge(T(i - 1), T(i))
+    i == 1 && return Edge(one(T), T(2))
+    i == 2 && return Edge(one(T), nvg)
+    return Edge(T(i - 1), T(i))
 end
 
 Base.IndexStyle(::Type{<:SimpleEdgeVector{V, G}}) where {V, G <: CycleGraph} = IndexLinear()
@@ -114,9 +114,9 @@ Base.IndexStyle(::Type{<:SimpleEdgeVector{V, G}}) where {V, G <: CycleGraph} = I
     return OutNeighborVector(g, eltype(g)(v))
 end
 
-LG.inneighbors(g::CycleGraph, v::Integer) = LG.outneighbors(g, v)
+LG.inneighbors(g::CycleGraph, v::Integer) = outneighbors(g, v)
 
-# ---- neighbors iterator -----------------------------------
+# ---- neighbors vector -----------------------------------
 
 function Base.size(nbs::OutNeighborVector{V, G}) where {V, G <: CycleGraph}
 
@@ -156,6 +156,6 @@ Base.IndexStyle(::Type{<:OutNeighborVector{V, G}}) where {V, G <: CycleGraph} = 
 #         converting
 # =======================================================
 
-Base.convert(::Type{LG.SimpleGraph}, g::CycleGraph{T}) where {T} = cycle_graph(nv(g))
-Base.convert(::Type{LG.SimpleGraph{T}}, g::CycleGraph) where {T} = cycle_graph(T(nv(g)))
+Base.convert(::Type{SimpleGraph}, g::CycleGraph{T}) where {T} = cycle_graph(nv(g))
+Base.convert(::Type{SimpleGraph{T}}, g::CycleGraph) where {T} = cycle_graph(T(nv(g)))
 

--- a/src/CycleGraph.jl
+++ b/src/CycleGraph.jl
@@ -72,7 +72,7 @@ function LG.has_edge(g::CycleGraph{T}, u, v) where {T}
     nvg = nv(g)
     oneT = one(T)
     isinbounds = (oneT <= u) & (v <= nvg) 
-    isedge = (v - u == oneT) | ((u == oneT) & (v == nvg))  
+    isedge = (v - u == oneT) | (v - u == nvg - oneT)
     return isinbounds & isedge
 end
 

--- a/src/CycleGraph.jl
+++ b/src/CycleGraph.jl
@@ -25,7 +25,7 @@ struct CycleGraph{T<:Integer} <: LG.AbstractGraph{T}
     end
 end
 
-CycleGraph(nv) = CycleGraph{typeof(nv)}(nv)
+CycleGraph(nv::T) where {T<: Integer} = CycleGraph{T}(nv)
 
 
 # =======================================================

--- a/src/CycleGraph.jl
+++ b/src/CycleGraph.jl
@@ -17,7 +17,7 @@ CycleGraph(nv) = CycleGraph{typeof(nv)}(nv)
 Base.eltype(::Type{CycleGraph{T}}) where {T} = T
 Base.eltype(g::CycleGraph) = eltype(typeof(g))
 LG.edgetype(::Type{CycleGraph{T}}) where {T} = LG.Edge{T}
-LG.edgetype(g::CycleGraph{T}) where {T} = edgetype(typeof(g))
+LG.edgetype(g::CycleGraph{T}) where {T} = LG.edgetype(typeof(g))
 
 LG.is_directed(::Type{<:CycleGraph}) = false
 

--- a/src/CycleGraph.jl
+++ b/src/CycleGraph.jl
@@ -76,41 +76,32 @@ function LG.has_edge(g::CycleGraph{T}, u, v) where {T}
     return isinbounds & isedge
 end
 
-# ---- edges iterator -----------------------------------
+# ---- edges vector -----------------------------------
 
-LG.edges(g::CycleGraph) = LG.SimpleGraphs.SimpleEdgeIter(g)
+LG.edges(g::CycleGraph) = SimpleEdgeVector(g)
 
-Base.eltype(::Type{<:LG.SimpleGraphs.SimpleEdgeIter{G}}) where {T, G <: CycleGraph{T}} =
-    LG.Edge{T}
+function Base.size(edgevec::SimpleEdgeVector{V, G}) where {V, G <: CycleGraph}
 
-function LG.iterate(iter::LG.SimpleGraphs.SimpleEdgeIter{G}) where {G <: CycleGraph}
+    g = edgevec.graph
 
-    g = iter.g
-    nvg = LG.nv(g)
+    return (ne(g), )
+end
+
+# TODO propagate inbounds
+function Base.getindex(edgevec::SimpleEdgeVector{V, G}, i::Int) where {V, G <: CycleGraph}
+
+    i ∈ Base.OneTo(length(edgevec)) || throw(BoundsError(edgevec, i))
+
+    g = edgevec.graph
     T = eltype(g)
+    nvg::T = nv(g)
 
-    nvg <= one(T) && return nothing
-
-    e = LG.Edge{T}(one(T), T(2))
-    nvg == T(2) && return e, T(2)
-
-    return e, T(1) 
+    i == 1 && return LG.Edge(one(T), T(2))
+    i == 2 && return LG.Edge(one(T), nvg)
+    return LG.Edge(T(i - 1), T(i))
 end
 
-function LG.iterate(iter::LG.SimpleGraphs.SimpleEdgeIter{G}, state) where {G <: CycleGraph}
-
-    g = iter.g
-    nvg = nv(g)
-    T = eltype(g) 
-
-   state == nvg && return nothing
-    src = state
-    dst = ifelse(state == one(T), nvg, state + one(T))
-    e = LG.Edge{T}(src, dst)
-        
-    return e, (state + one(T))
-
-end
+Base.IndexStyle(::Type{<:SimpleEdgeVector{V, G}}) where {V, G <: CycleGraph} = IndexLinear()
 
 
 # =======================================================

--- a/src/CycleGraph.jl
+++ b/src/CycleGraph.jl
@@ -3,6 +3,16 @@
 #         CycleGraph struct
 # =======================================================
 
+"""
+    CycleGraph <: AbstractGraph
+
+A structure representing an undirected cycle graph.
+
+A `CycleGraph` with one vertex is a single vertex without any edges (no self-loops)
+and a `CycleGraph` with two vertices is a single edge.
+
+See also: [`LightGraphs.cycle_graph`](@ref)
+"""
 struct CycleGraph{T<:Integer} <: LG.AbstractGraph{T}
     nv::T
 

--- a/src/CycleGraph.jl
+++ b/src/CycleGraph.jl
@@ -109,13 +109,13 @@ Base.IndexStyle(::Type{<:SimpleEdgeVector{V, G}}) where {V, G <: CycleGraph} = I
 # =======================================================
 
 # TODO maybe we want an inbounds check
-LG.outneighbors(g::CycleGraph, v::Integer) = OutNeighborsVector(g, eltype(g)(v))
+LG.outneighbors(g::CycleGraph, v::Integer) = OutNeighborVector(g, eltype(g)(v))
 
 LG.inneighbors(g::CycleGraph, v::Integer) = LG.outneighbors(g, v)
 
 # ---- neighbors iterator -----------------------------------
 
-function Base.size(nbs::OutNeighborsVector{V, G}) where {V, G <: CycleGraph}
+function Base.size(nbs::OutNeighborVector{V, G}) where {V, G <: CycleGraph}
 
     g = nbs.graph
     T = eltype(g)
@@ -127,7 +127,7 @@ function Base.size(nbs::OutNeighborsVector{V, G}) where {V, G <: CycleGraph}
 end
 
 # TODO propagate inbounds
-function Base.getindex(nbs::OutNeighborsVector{V, G}, i::Int) where {V, G <: CycleGraph}
+function Base.getindex(nbs::OutNeighborVector{V, G}, i::Int) where {V, G <: CycleGraph}
 
     i ∈ Base.OneTo(length(nbs)) || throw(BoundsError(nbs, i))
 
@@ -144,7 +144,7 @@ function Base.getindex(nbs::OutNeighborsVector{V, G}, i::Int) where {V, G <: Cyc
     return (v == nvg) ? (nvg(T) - 1) : (v + one(T))
 end
 
-Base.IndexStyle(::Type{<:OutNeighborsVector{V, G}}) where {V, G <: CycleGraph} = IndexLinear()
+Base.IndexStyle(::Type{<:OutNeighborVector{V, G}}) where {V, G <: CycleGraph} = IndexLinear()
 
 
 # =======================================================

--- a/src/CycleGraph.jl
+++ b/src/CycleGraph.jl
@@ -121,8 +121,6 @@ end
 LG.outneighbors(g::CycleGraph, v::Integer) = OutNeighborsIter(g, eltype(g)(v))
 
 LG.inneighbors(g::CycleGraph, v::Integer) = LG.outneighbors(g, v)
-LG.neighbors(g::CycleGraph, v::Integer) = LG.outneighbors(g, v)
-LG.all_neighbors(g::CycleGraph, v::Integer) = LG.outneighbors(g, v)
 
 # ---- neighbors iterator -----------------------------------
 

--- a/src/CycleGraph.jl
+++ b/src/CycleGraph.jl
@@ -116,16 +116,11 @@ LG.all_neighbors(g::CycleGraph, v::Integer) = LG.outneighbors(g, v)
 
 # ---- neighbors iterator -----------------------------------
 
-struct OutNeighborsIter{T, G <: LG.AbstractGraph{T}}
-    graph::G
-    vertex::T
-end
 
-Base.eltype(::Type{<:OutNeighborsIter{T, G}}) where {T, G} = eltype(G)  
-
-function LG.iterate(iter::OutNeighborsIter{T, G}) where {T, G <: CycleGraph}
+function LG.iterate(iter::OutNeighborsIter{V, <:CycleGraph}) where {V}
 
     g = iter.graph
+    T = eltype(g)
     v = iter.vertex
     nvg = nv(g)
 
@@ -137,17 +132,19 @@ function LG.iterate(iter::OutNeighborsIter{T, G}) where {T, G <: CycleGraph}
     return (v - one(T)), (v + one(T))
 end
 
-function LG.iterate(iter::OutNeighborsIter{T, G}, state) where {T, G <: CycleGraph}
+function LG.iterate(iter::OutNeighborsIter{V, <:CycleGraph}, state) where {V}
 
     g = iter.graph
+    T = eltype(g)
 
     state == zero(T) && return nothing
     return state, zero(T)
 end
 
-function Base.length(iter::OutNeighborsIter{T, G}) where {T, G <: CycleGraph}
+function Base.length(iter::OutNeighborsIter{V, <:CycleGraph}) where {V}
 
     g = iter.graph
+    T = eltype(g)
     nvg = nv(g)
 
     nvg <= one(T) && return 0

--- a/src/CycleGraph.jl
+++ b/src/CycleGraph.jl
@@ -166,5 +166,6 @@ end
 #         converting
 # =======================================================
 
-LG.SimpleGraph(g::CycleGraph) = LG.cycle_graph(nv(g))
+Base.convert(::Type{LG.SimpleGraph}, g::CycleGraph{T}) where {T} = cycle_graph(nv(g))
+Base.convert(::Type{LG.SimpleGraph{T}}, g::CycleGraph) where {T} = cycle_graph(T(nv(g)))
 

--- a/src/SpecialGraphs.jl
+++ b/src/SpecialGraphs.jl
@@ -3,12 +3,15 @@ module SpecialGraphs
 import LightGraphs
 const LG = LightGraphs
 
+import Base.eltype
+
 using LightGraphs: nv, ne, outneighbors,
                    inneighbors, vertices, edges, Edge,
                    has_vertex, has_edge
 
-export WheelGraph, PathGraph, CompleteGraph
+export CycleGraph, WheelGraph, PathGraph, CompleteGraph
 
+include("CycleGraph.jl")
 include("WheelGraph.jl")
 include("PathGraph.jl")
 include("CompleteGraph.jl")

--- a/src/SpecialGraphs.jl
+++ b/src/SpecialGraphs.jl
@@ -3,7 +3,7 @@ module SpecialGraphs
 import LightGraphs
 const LG = LightGraphs
 
-import Base.eltype, Base.convert
+import Base.eltype, Base.convert, Base.size, Base.getindex, Base.IndexStyle
 
 using LightGraphs: nv, ne, outneighbors,
                    inneighbors, vertices, edges, Edge,

--- a/src/SpecialGraphs.jl
+++ b/src/SpecialGraphs.jl
@@ -3,11 +3,11 @@ module SpecialGraphs
 import LightGraphs
 const LG = LightGraphs
 
-import Base.eltype
+import Base.eltype, Base.convert
 
 using LightGraphs: nv, ne, outneighbors,
                    inneighbors, vertices, edges, Edge,
-                   has_vertex, has_edge
+                   has_vertex, has_edge, SimpleGraph, cycle_graph
 
 export CycleGraph, WheelGraph, PathGraph, CompleteGraph
 

--- a/src/SpecialGraphs.jl
+++ b/src/SpecialGraphs.jl
@@ -11,6 +11,7 @@ using LightGraphs: nv, ne, outneighbors,
 
 export CycleGraph, WheelGraph, PathGraph, CompleteGraph
 
+include("utils.jl")
 include("CycleGraph.jl")
 include("WheelGraph.jl")
 include("PathGraph.jl")

--- a/src/SpecialGraphs.jl
+++ b/src/SpecialGraphs.jl
@@ -5,7 +5,8 @@ const LG = LightGraphs
 
 import Base.eltype, Base.convert, Base.size, Base.getindex, Base.IndexStyle
 
-using LightGraphs: nv, ne, outneighbors,
+using LightGraphs: AbstractGraph, SimpleGraph,
+                   nv, ne, outneighbors, edgetype,
                    inneighbors, vertices, edges, Edge,
                    has_vertex, has_edge, SimpleGraph, cycle_graph
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -10,4 +10,12 @@ struct OutNeighborsVector{V, G <: LG.AbstractGraph{V}} <: AbstractVector{V}
     vertex::V
 end
 
+"""
+    SimpleEdgeVector
+
+A structure for iterating over the edges of a graph
+"""
+struct SimpleEdgeVector{V, G <: LG.AbstractGraph{V}} <: AbstractVector{LG.Edge{V}}
+    graph::G
+end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,14 @@
+
+
+"""
+    OutNeighborsIter
+
+A structure for iterating over the out neighbors in a graph for a certain vertex.
+"""
+struct OutNeighborsIter{V, G <: LG.AbstractGraph{V}}
+    graph::G
+    vertex::V
+end
+
+Base.eltype(::Type{<:OutNeighborsIter{V, G}}) where {V, G} = eltype(G)  
+

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -5,10 +5,9 @@
 
 A structure for iterating over the out neighbors in a graph for a certain vertex.
 """
-struct OutNeighborsIter{V, G <: LG.AbstractGraph{V}}
+struct OutNeighborsVector{V, G <: LG.AbstractGraph{V}} <: AbstractVector{V}
     graph::G
     vertex::V
 end
 
-Base.eltype(::Type{<:OutNeighborsIter{V, G}}) where {V, G} = eltype(G)  
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,11 +1,11 @@
 
 
 """
-    OutNeighborsIter
+    OutNeighborVector <: AbstractVector
 
 A structure for iterating over the out neighbors in a graph for a certain vertex.
 """
-struct OutNeighborsVector{V, G <: LG.AbstractGraph{V}} <: AbstractVector{V}
+struct OutNeighborVector{V, G <: LG.AbstractGraph{V}} <: AbstractVector{V}
     graph::G
     vertex::V
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -11,7 +11,7 @@ struct OutNeighborVector{V, G <: LG.AbstractGraph{V}} <: AbstractVector{V}
 end
 
 """
-    SimpleEdgeVector
+    SimpleEdgeVector <: AbstractVector
 
 A structure for iterating over the edges of a graph
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -242,12 +242,20 @@ end
             end
         end
 
-        @testset "converting to SimpleGraph" begin
+        @testset "convert(SimpleGraph, g)" begin
 
-            gsimple = LG.SimpleGraph(g)
+            gsimple = convert(LG.SimpleGraph, g)
             @test gsimple == LG.cycle_graph(T(n))
             @test eltype(g) == eltype(gsimple)
         end
+
+        @testset "convert(SimpleGraph{$T2}, g)" for T2 in (UInt32, Int64, UInt64)
+
+            gsimple = convert(LG.SimpleGraph{T2}, g)
+            @test gsimple == LG.cycle_graph(T2(n))
+            @test eltype(gsimple) == T2
+        end
+
 
         @testset "pagerank" begin
             if n > 0 # pagerank does not work for empty graphs

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -161,7 +161,7 @@ end
         end
 
         @testset "has_edge(g, $src, $dst)" for
-            (src, dst) in [(1, 2), (2, 1), (1, 3), (0, 1), (1, n), (n, 1), (n, n +1)]
+            (src, dst) in [(1, 1), (1, 2), (2, 1), (1, 3), (0, 1), (1, n), (n, 1), (n, n +1)]
 
             has_edge_expected =
                 src in 1:n && dst in 1:n &&

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -178,6 +178,10 @@ end
                 @test eltype(typeof(edges)) == LG.edgetype(g)
             end
 
+            @testset "correct IndexStyle" begin
+                @test IndexStyle(edges) == IndexLinear()
+            end
+
             @testset "length" begin
                 @test length(edges) == LG.ne(g)
             end
@@ -204,6 +208,10 @@ end
             @testset "eltype" begin
                 @test eltype(outneighbors) == T
                 @test eltype(typeof(outneighbors)) == T
+            end
+
+            @testset "correct IndexStyle" begin
+                @test IndexStyle(outneighbors) == IndexLinear()
             end
 
             @testset "length" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -180,6 +180,7 @@ end
 
             @testset "correct IndexStyle" begin
                 @test IndexStyle(edges) == IndexLinear()
+                @test IndexStyle(typeof(edges)) == IndexLinear()
             end
 
             @testset "length" begin
@@ -212,6 +213,7 @@ end
 
             @testset "correct IndexStyle" begin
                 @test IndexStyle(outneighbors) == IndexLinear()
+                @test IndexStyle(typeof(outneighbors)) == IndexLinear()
             end
 
             @testset "length" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -197,6 +197,10 @@ end
         @testset "outneigbors(g, $v)" for v in (unique([1, 2, n - 1, n]) ∩ LG.vertices(g))
             outneighbors = LG.outneighbors(g, v)
 
+            @testset "same as inneighbors" begin
+                @test LG.inneighbors(g, v) == outneighbors
+            end
+
             @testset "eltype" begin
                 @test eltype(outneighbors) == T
                 @test eltype(typeof(outneighbors)) == T
@@ -236,6 +240,13 @@ end
                     @test (n1, n2) == (n1_expected, n2_expected)
                 end
             end
+        end
+
+        @testset "converting to SimpleGraph" begin
+
+            gsimple = LG.SimpleGraph(g)
+            @test gsimple == LG.cycle_graph(T(n))
+            @test eltype(g) == eltype(gsimple)
         end
 
         @testset "pagerank" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,3 +90,149 @@ end
         end
     end
 end
+
+@testset "CycleGraph" begin
+    @testset "CycleGraph{T}(n): (T = $T, n = $n)" for
+        T in [UInt8, Int32, Int64],
+        n in [0, 1, 2, 3, 8] ∪ (T == UInt8 ? (255,) : ()) # extremal case for UInt8
+
+        @testset "Constructor CycleGraph(n::T)" begin
+            g = CycleGraph(T(n))
+
+            @test typeof(g) == CycleGraph{T}
+            @test LG.nv(g) == n
+        end
+
+        @testset "Constructor CycleGraph{T}(n)" begin
+            g = CycleGraph{T}(n)
+
+            @test typeof(g) == CycleGraph{T}
+            @test LG.nv(g) == n
+        end
+
+        g = CycleGraph{T}(n)
+
+        @testset "vertices(g)" begin
+            @test eltype(LG.vertices(g)) == T
+            @test collect(LG.vertices(g)) == 1:n
+        end
+
+        @testset "ne(g)" begin
+            @test typeof(LG.ne(g)) == Int
+            ne_expected =
+                if n == 0 || n == 1
+                    0
+                elseif n == 2
+                    1
+                else
+                    n
+                end
+            @test LG.ne(g) == ne_expected
+        end
+
+        @testset "eltype" begin
+            @test eltype(g) == T
+            @test eltype(typeof(g)) == T
+        end
+
+        @testset "edgetype" begin
+            @test LG.edgetype(g) == LG.Edge{T}
+            @test LG.edgetype(typeof(g)) == LG.Edge{T}
+        end
+
+        @testset "is_directed" begin
+            @test LG.is_directed(typeof(g)) == false
+        end
+
+        @testset "has_vertex(g, $v)" for
+            v in [-1, 0, 1, 2, 255]
+
+            has_vertex_expected = v ∈ 1:n
+            @test LG.has_vertex(g, v) == has_vertex_expected
+        end
+
+        @testset "has_edge(g, $src, $dst)" for
+            (src, dst) in [(1, 2), (2, 1), (1, 3), (0, 1), (1, n), (n, 1), (n, n +1)]
+
+            has_edge_expected =
+                src in 1:n && dst in 1:n &&
+                ((max(src, dst) - min(src, dst) == 1) || (min(src, dst) == 1 && max(src, dst) == n))
+
+            @test LG.has_edge(g, src, dst) == has_edge_expected
+        end
+
+        @testset "edges(g)" begin
+            edges = LG.edges(g)
+
+            @testset "eltype" begin
+                @test eltype(edges) == LG.edgetype(g)
+                @test eltype(typeof(edges)) == LG.edgetype(g)
+            end
+
+            @testset "length" begin
+                @test length(edges) == LG.ne(g)
+            end
+
+            @testset "lexicographicaly sorted and unique" begin
+                # No order defined on Edge so we convert to Tuple first
+                tuples = map(Tuple, edges)
+                @test issorted(tuples)
+                @test allunique(tuples)
+            end
+
+            @testset "are edges of g" begin
+                @test all(e -> LG.has_edge(g, e), edges)
+            end
+        end
+
+        @testset "outneigbors(g, $v)" for v in (unique([1, 2, n - 1, n]) ∩ LG.vertices(g))
+            outneighbors = LG.outneighbors(g, v)
+
+            @testset "eltype" begin
+                @test eltype(outneighbors) == T
+                @test eltype(typeof(outneighbors)) == T
+            end
+
+            @testset "length" begin
+                length_expected =
+                    if n == 0 || n == 1
+                        0
+                    elseif n == 2
+                        1
+                    else
+                        2
+                    end
+                @test length(outneighbors) == length_expected
+            end
+
+            @testset "issorted and unique" begin
+                @test issorted(outneighbors)
+                @test allunique(outneighbors)
+            end
+
+            @testset "correct values" begin
+                if n == 2
+                    @test first(outneighbors) == (v == 1 ? 2 : 1)
+                elseif n >= 3
+                    n1, n2 = outneighbors
+
+                    n1_expected, n2_expected =
+                        if v == 1
+                            (2, n)
+                        elseif v == n
+                            (1, n - 1)
+                        else
+                            (v - 1, v + 1)
+                        end
+                    @test (n1, n2) == (n1_expected, n2_expected)
+                end
+            end
+        end
+
+        @testset "pagerank" begin
+            if n > 0 # pagerank does not work for empty graphs
+                @test LG.pagerank(g) ≈ LG.pagerank(LG.cycle_graph(T(n)))
+            end
+        end
+    end
+end


### PR DESCRIPTION
My other PR #10 was maybe a bit prematurely merged. On the other hand now I have my fourth PR for hacktoberfest, so this is also not too bad...

In this PR I replaced the neighbors and edge iterators with vectors `<: AbstractVector`.
One thing that I noticed was that I have now a lot of branching. Maybe the compiler is clever enough to convert them to some branchless expression or maybe that can be added in a later PR.